### PR TITLE
refresh 토큰을 이용한 accessToken 재발급

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -67,7 +67,7 @@ export class AuthController {
      * @param user - 현재 사용자 정보
      * @returns 새로 생성된 액세스 토큰
      */
-    @Get('/refresh')
+    @Post('/refresh')
     @UseGuards(AuthGuard('jwt-refresh'))
     @HttpCode(HttpStatus.OK)
     async refresh(@GetUser() user: User) {

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { User } from 'src/users/entities/user.entity';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { JwtRefreshStrategy } from './strategies/jwt-refresh.strategy';
 import { UsersModule } from 'src/users/users.module';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AllConfigType } from 'src/configs/types/config.type';
@@ -29,7 +30,7 @@ import { MailModule } from 'src/mail/mail.moudle';
         MailModule
     ],
     controllers: [AuthController],
-    providers: [AuthService, JwtStrategy],
-    exports: [JwtStrategy]
+    providers: [AuthService, JwtStrategy, JwtRefreshStrategy],
+    exports: [JwtStrategy, JwtRefreshStrategy]
 })
 export class AuthModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ async function bootstrap() {
         origin: configService.get('app.frontendDomain', { infer: true }),
         credentials: true,
         methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-        allowedHeaders: 'Content-Type, Accept'
+        allowedHeaders: 'Content-Type, Accept, Authorization'
     });
     app.useGlobalPipes(new ValidationPipe(validationOptions));
 


### PR DESCRIPTION
### 구현 내용
- accessToken 이 만료되었을 경우 /auth/refresh 에 POST 로 body 에 refreshToken 을 담아 요청한다
- refreshToken 의 만료를 passport JwtRefreshStrategy 에서 확인하고 만료되었다면 자동으로 401 Unauthorized 를 반환한다. (암시적으로 ignoreExpiration: false 가 설정되어 있기 때문에 만료된 토큰이라면 validate 가 실행되지 않는다.) 
-  만료되지 않은 요청이라면 validate 에서 데이터베이스에 저장되어있는 사용자의 refreshToken 과 Body 의 refreshToken 을 비교하고 일치한다면 사용자 정보를 req 객체에 저장해 활용한다.
- 브라우저 로그파일 및 주소에 토큰이 노출되는 것을 방지하기 위해 GET 대신 POST 로 요청한다.