### PR TITLE
외래키 제약조건에 의한 게시물 삭제 에러 해결

### DIFF
--- a/src/comment/entities/comment.entity.ts
+++ b/src/comment/entities/comment.entity.ts
@@ -30,13 +30,11 @@ export class Comment {
     @JoinColumn({ name: 'userId' })
     user: User;
 
-    @ManyToOne(() => Post, post => post.comments)
+    @ManyToOne(() => Post, post => post.comments, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'postId' })
     post: Post;
 
-    @ManyToOne(() => Comment, comment => comment.replies, {
-        onDelete: 'CASCADE'
-    })
+    @ManyToOne(() => Comment, comment => comment.replies, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'parentCommentId' })
     parentComment: Comment;
 


### PR DESCRIPTION
```ts
// comment.entity.ts
@ManyToOne(() => Post, post => post.comments, { onDelete: 'CASCADE' })
@JoinColumn({ name: 'postId' })
post: Post;

// post.entity.ts 
@OneToMany(() => Comment, comment => comment.post)
comments: Comment[];
```
### 참고 링크
https://stackoverflow.com/questions/55098023/typeorm-cascade-option-cascade-ondelete-onupdate