### PR TITLE
Gravatar 프로필 이미지 추가

### DIFF
--- a/src/gravatar/gravatar.module.ts
+++ b/src/gravatar/gravatar.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { GravatarService } from './gravatar.service';
+
+@Module({
+    providers: [GravatarService],
+    exports: [GravatarService]
+})
+export class GravatarModule {}

--- a/src/gravatar/gravatar.service.ts
+++ b/src/gravatar/gravatar.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class GravatarService {
+    getGravatarUrl(email: string, size: number = 200): string {
+        const md5EmailHash = crypto.createHash('md5').update(email.trim().toLowerCase()).digest('hex');
+
+        return `https://www.gravatar.com/avatar/${md5EmailHash}?s=${size}&d=retro`;
+    }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -23,6 +23,9 @@ export class User extends BaseEntity {
     @Column({ nullable: true })
     description: string;
 
+    @Column({ nullable: true })
+    profileImage: string;
+
     @Column({ type: 'text' })
     password: string;
 

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { GravatarModule } from 'src/gravatar/gravatar.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([User])],
+    imports: [TypeOrmModule.forFeature([User]), GravatarModule],
     controllers: [UsersController],
     providers: [UsersService],
     exports: [UsersService]

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -7,16 +7,25 @@ import { User } from './entities/user.entity';
 import { NullableType } from 'src/utils/types/nullable.type';
 import { FindOneOptions } from 'typeorm';
 import * as bcrypt from 'bcrypt';
+import { GravatarService } from 'src/gravatar/gravatar.service';
 
 @Injectable()
 export class UsersService {
     constructor(
         @InjectRepository(User)
-        private usersRepository: Repository<User>
+        private usersRepository: Repository<User>,
+        private gravatarService: GravatarService
     ) {}
 
     async create(createUserDto: CreateUserDto): Promise<User> {
-        return this.usersRepository.save(this.usersRepository.create(createUserDto));
+        const { email } = createUserDto;
+        const profileImage = this.gravatarService.getGravatarUrl(email);
+        return this.usersRepository.save(
+            this.usersRepository.create({
+                ...createUserDto,
+                profileImage
+            })
+        );
     }
 
     async findOne(findOptions: FindOneOptions<User>): Promise<NullableType<User>> {


### PR DESCRIPTION
- 사용자 생성시 기본 이미지로 gravatar 이미지 추가
- 사용자 이메일을 이용해 MD5 해시를 생성하고 프로필 이미지 url 생성
- 다른 기능을 구현할 때 재사용할 수 있으므로 별도 gravatar 모듈을 이용해 DI 가 가능하도록 구현