### PR TITLE
사용자 프로필 업데이트에 대한 테스트코드 변경

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -27,6 +27,7 @@ export class UsersService {
         return this.usersRepository.save(
             this.usersRepository.create({
                 ...createUserDto,
+                description: '',
                 profileImage
             })
         );

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -75,7 +75,7 @@ describe('UserController (e2e)', () => {
             expect(user).toHaveProperty('nickname');
             expect(user).toHaveProperty('userLoginId');
         });
-        
+
         it('존재하지 않는 사용자라면 404 NotFound 를 반환한다.', async () => {
             await request(app.getHttpServer())
                 .get(`/users/public/profile/${encodeURIComponent('가나다')}`)
@@ -94,7 +94,7 @@ describe('UserController (e2e)', () => {
                     nickname,
                     description
                 })
-                .expect(204);
+                .expect(200);
             const response = await request(app.getHttpServer())
                 .get('/users/profile')
                 .set('Authorization', `Bearer ${accessToken}`);
@@ -111,7 +111,7 @@ describe('UserController (e2e)', () => {
                 .send({
                     password: password
                 })
-                .expect(204);
+                .expect(200);
             const response = await request(app.getHttpServer())
                 .get('/users/profile')
                 .set('Authorization', `Bearer ${accessToken}`);


### PR DESCRIPTION
- description 에 null 값이 허용되지 않도록 변경
- patch 메소드의 204 대신 사용자 엔티티를 담아 응답하면서 200 으로 상태코드 변경